### PR TITLE
Fix some typings errors in typescript 2.1.x

### DIFF
--- a/package/index.ts
+++ b/package/index.ts
@@ -559,11 +559,11 @@ export class UploadArea {
         let entry;
         for (let i = 0; i < items.length; i++) {
             let item: IFileExt = <IFileExt>items[i];
-            if ((item.webkitGetAsEntry) && (entry = item.webkitGetAsEntry())) {
+            if ((item.webkitGetAsEntry) && (entry = <IFileExt>item.webkitGetAsEntry())) {
                 if (entry.isFile) {
                     this.putFilesToQueue([item.getAsFile()], this.fileInput);
                 } else if (entry.isDirectory) {
-                    this.processDirectory(entry, entry.name);
+                    this.processDirectory(entry as any, entry.name);
                 }
             } else if (item.getAsFile) {
                 if (!item.kind || item.kind === 'file') {

--- a/src/area/uploadArea.ts
+++ b/src/area/uploadArea.ts
@@ -334,11 +334,11 @@ class UploadArea {
         let entry;
         for (let i = 0; i < items.length; i++) {
             let item: IFileExt = <IFileExt>items[i];
-            if ((item.webkitGetAsEntry) && (entry = item.webkitGetAsEntry())) {
+            if ((item.webkitGetAsEntry) && (entry = <IFileExt>item.webkitGetAsEntry())) {
                 if (entry.isFile) {
                     this.putFilesToQueue([item.getAsFile()], this.fileInput);
                 } else if (entry.isDirectory) {
-                    this.processDirectory(entry, entry.name);
+                    this.processDirectory(entry as any, entry.name);
                 }
             } else if (item.getAsFile) {
                 if (!item.kind || item.kind === 'file') {


### PR DESCRIPTION
After upgrading to TypeScript 2.1.x, we are getting errors with some typings that don't exist as shown here:

![image](https://cloud.githubusercontent.com/assets/600962/21118791/562d0776-c074-11e6-89e9-0f3fcf5c4d12.png)

This PR addresses these issues.